### PR TITLE
Update README with HTTPS cloning URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Clone this repository:
 ```bash
 git clone git@github.com:JuulLabs-OSS/kotlin-code-styles.git
 ```
+or
+```bash
+git clone https://github.com/JuulLabs-OSS/kotlin-code-styles.git
+```
 
  Run the install script:
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,12 @@ IntelliJ IDEA code style settings for JUUL Labs' Kotlin and Android projects.
 Clone this repository:
 
 ```bash
-git clone git@github.com:JuulLabs-OSS/kotlin-code-styles.git
-```
-or
-```bash
 git clone https://github.com/JuulLabs-OSS/kotlin-code-styles.git
 ```
 
- Run the install script:
+_See [Which remote URL should I use?] for alternate ways of cloning repository._
+
+Run the install script:
 
 ```bash
 cd kotlin-code-styles/
@@ -54,3 +52,4 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 
 [Kotlin style guide]: https://developer.android.com/kotlin/style-guide
 [#1]: https://github.com/JuulLabs-OSS/kotlin-code-styles/issues/1
+[Which remote URL should I use?]: https://help.github.com/en/github/using-git/which-remote-url-should-i-use


### PR DESCRIPTION
Updated README with HTTPS cloning URL, as it's the [recommended] approach.

[recommended]: https://help.github.com/en/github/using-git/which-remote-url-should-i-use#cloning-with-https-urls-recommended